### PR TITLE
feat : 5주차 - 민협

### DIFF
--- a/minhyeop/kim/PGS_연속펄스부분수열의합.java
+++ b/minhyeop/kim/PGS_연속펄스부분수열의합.java
@@ -1,0 +1,31 @@
+package minhyeop.kim;
+
+class PGS_연속펄스부분수열의합 {
+
+    public static void main(String[] args) {
+        System.out.println(solution(new int[] {2, 3, -6, 1, 3, -1, 2, 4}));
+    }
+
+    public static long solution(int[] sequence) {
+        int a = 1, b = -1, size = sequence.length;
+        long aSum = sequence[0], bSum = sequence[0] * -1, aMin = 0, bMin = 0, max = Long.MIN_VALUE;
+
+        for (int i = 1; i <= size; i++) {
+            a *= -1;
+            b *= -1;
+
+            max = Math.max(max, aSum - aMin);
+            max = Math.max(max, bSum - bMin);
+
+            aMin = Math.min(aMin, aSum);
+            bMin = Math.min(bMin, bSum);
+
+            if (i == size) break;
+
+            aSum += sequence[i] * a;
+            bSum += sequence[i] * b;
+        }
+
+        return max;
+    }
+}


### PR DESCRIPTION
## 문제 링크
[연속 펄스 부분 수열의 합](https://school.programmers.co.kr/learn/courses/30/lessons/161988)

## 문제 접근 방식
* 처음으로 생각했고 구현했던 방식은 첫 인덱스부터 마지막 인덱스까지, 각 인덱스부터 시작하는 연속펄스부분수열의 최대값을 구하는 방식이었습니다. 그러나 시간 초과로 인해 O(N)으로 해결해야 함을 확인할 수 있었습니다.
* 최종 정답 수열의 어떤 한 인덱스에서 좌우 방향으로 인덱스를 끝까지 탐색하면 정답을 구할 수 있다는 논리를 깨달아서, 최종 정답 수열에 무조건 포함되는 인덱스를 찾고자 시간을 많이 쏟았습니다. (끝까지 못 찾았습니다..)
* 그래서 GPT에게 힌트를 받아서 정답에 도달했습니다..
* a와 b는 각각 1과 -1로 시작하는 펄스수열입니다.
* max는 현재의 a/b수열의 합(aSum/bSum)에서 그 때까지의 최솟값(aMin/bMin)을 뺀 값과 비교하여 갱신합니다.

### 문제를 풀면서 생겼던 질문
* 문제를 푸시면서 초반 단계의 (정답으로 이어지지는 못하는) 논리에 확신을 갖게 되었을 때, 어떤 포인트에 도달하면 다시 다른 풀이를 모색하시는지 궁금합니다.